### PR TITLE
Selenium failing to realize when page loads at "And I click 'btnG' button and wait"

### DIFF
--- a/pyccuracy/actions/core/element_actions.py
+++ b/pyccuracy/actions/core/element_actions.py
@@ -133,7 +133,7 @@ This action instructs the browser driver to click the given element. If the "and
         context.browser_driver.click_element(element_key)
 
         if (should_wait):
-            timeout = 30000
+            timeout = 5000
             try:
                 context.browser_driver.wait_for_page(timeout=timeout)
             except Exception, error:

--- a/pyccuracy/drivers/core/selenium_driver.py
+++ b/pyccuracy/drivers/core/selenium_driver.py
@@ -72,8 +72,11 @@ class SeleniumDriver(BaseDriver):
     def page_open(self, url):
         self.selenium.open(url)
 
-    def wait_for_page(self, timeout=30000):
-        self.selenium.wait_for_page_to_load(timeout)
+    def wait_for_page(self, timeout=5000):
+        try:
+            self.selenium.wait_for_page_to_load(timeout)
+        except Exception, e: # Selenium is not perceiving some loads, so ignore it
+            pass
 
     def click_element(self, element_selector):
         self.selenium.click(element_selector)


### PR DESCRIPTION
To start with pyccuracy I made the examples on manual, but they are not working because Selenium is failing to realize when a page was loaded after a "And I click 'btnG' button and wait" on the following example:

```
As a Google User
I want to search Google
So that I can test Pyccuracy

Scenario 1 - Searching for Hello World
Given
    I go to "http://www.google.com"
When
    I fill "q" textbox with "Hello World"
    And I click "btnG" button and wait   <-- FAILED - The action wait for page to load timed out after waiting for 30000 ms.
Then
    I see "Hello World - Pesquisa Google" title
```

I am using selenium-server.jar from pyccuracy/lib folder, and Firefox version 3.6.13 (Mozilla/5.0 (X11; U; Linux i686; pt-BR; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13) from package firefox-mozilla-build of Ubuntu 10.10

I tested against Pyccuracy github:c98c1976ebfa99bad61e and patched it with a dirty workarround, so fell free to change it, but I'll be glad if you can confirm this bug and then point me what is wrong or a working version.

Thanks, Alan.
(and thanks more for bringing Cucumber to the snakes)
