### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyccuracy/actions/core/textbox_actions.py
+++ b/pyccuracy/actions/core/textbox_actions.py
@@ -103,7 +103,7 @@ This action types the given text in the given textbox. The difference between "s
             # I observed that it's only possible to type_keys after type_text once.
             TextboxTypeAction().execute(context, textbox_name, text)
         
-        # now typyng slowly...
+        # now typing slowly...
         textbox_key = self.resolve_element_key(context, Page.Textbox, textbox_name)
         context.browser_driver.type_keys(textbox_key, text)
 

--- a/pyccuracy/drivers/core/selenium_webdriver.py
+++ b/pyccuracy/drivers/core/selenium_webdriver.py
@@ -103,7 +103,7 @@ class SeleniumWebdriver(BaseDriver):
 
     def wait_for_page(self, timeout=30000):
         pass
-        # the new recomendation from selenium is to watch for an element only
+        # the new recommendation from selenium is to watch for an element only
         # present with the new situation, all wait functions were dropped
 
     def get_title(self):

--- a/pyccuracy/drivers/interface.py
+++ b/pyccuracy/drivers/interface.py
@@ -95,11 +95,11 @@ This method is called before any scenarios begin.'''
         raise NotImplementedError
 
     def get_selected_value(self, element_selector):
-        '''This methid gets the value for the currently selected option in the given select.'''
+        '''This method gets the value for the currently selected option in the given select.'''
         raise NotImplementedError
 
     def get_selected_text(self, element_selector):
-        '''This methid gets the text for the currently selected option in the given select.'''
+        '''This method gets the text for the currently selected option in the given select.'''
         raise NotImplementedError
 
     def get_element_text(self, element_selector):

--- a/tests/unit/airspeed_test.py
+++ b/tests/unit/airspeed_test.py
@@ -479,7 +479,7 @@ $email
     # so it's correct behavior by definition; the real
     # question is whether using them w/o a comma is a legal variant
     # or not.  This should effect the above test; the following test
-    # should be legal by defintion
+    # should be legal by definition
 
     def test_define_and_use_macro_with_two_parameters_with_comma(self):
         template = airspeed.Template('#macro ( bold $value, $other)<strong>$value</strong>$other#end#bold ($text, $monkey)')


### PR DESCRIPTION
There are small typos in:
- pyccuracy/actions/core/textbox_actions.py
- pyccuracy/drivers/core/selenium_webdriver.py
- pyccuracy/drivers/interface.py
- tests/unit/airspeed_test.py

Fixes:
- Should read `method` rather than `methid`.
- Should read `typing` rather than `typyng`.
- Should read `recommendation` rather than `recomendation`.
- Should read `definition` rather than `defintion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md